### PR TITLE
Community related pointers for the README

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,23 @@
+{
+  "creators": [
+    {
+      "affiliation": "Edit me!",
+      "name": "Edit me!",
+      "orcid": "Edit me!"
+    },
+    {
+      "affiliation": "Edit me!",
+      "name": "Edit me!",
+      "orcid": "Edit me!"
+    }
+  ],
+  "keywords": [
+    "data management",
+    "data distribution",
+    "execution provenance tracking",
+    "version control"
+  ],
+  "access_right": "open",
+  "license": "Edit me!",
+  "upload_type": "software"
+}

--- a/README.md
+++ b/README.md
@@ -23,4 +23,12 @@ DataLad will now expose a new command suite with `hello...` commands.
 To start implementing your own extension, fork this project and adjust
 as necessary. The comments in [setup.py](setup.py) and
 [__init__.py](datalad_helloworld/__init__.py) illustrate the purpose of the various
-aspects of a command implementation and the setup of an extension package. 
+aspects of a command implementation and the setup of an extension package.
+
+You can consider filling in the provided [.zenodo.json](.zenodo.json) file with
+contributor information and [meta data](https://developers.zenodo.org/#representation)
+to acknowledge contributors and describe the publication record that is created when
+[you make your code citeable](https://guides.github.com/activities/citable-code/)
+by archiving it using [zenodo.org](https://zenodo.org/). You may also want to
+consider acknowledging contributors with the
+[allcontributors bot](https://allcontributors.org/docs/en/bot/overview).


### PR DESCRIPTION
This mentions zenodo and adds a .zenodo.json file to start with, and it briefly references the allcontributors bot.