### PR TITLE
Use released version of datalad-installer

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -74,6 +74,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       # Python version specification is non-standard on windows
       PY: 39-x64
+      INSTALL_GITANNEX: git-annex -m datalad/packages
     # MacOS core tests
     - ID: MacP38core
       DTS: datalad_helloworld
@@ -130,8 +131,6 @@ init:
   - cmd: "set TMP=C:\\DLTMP"
   - cmd: "set TEMP=C:\\DLTMP"
   - sh: export TMPDIR=~/DLTMP
-  # deploy the datalad installer
-  - appveyor DownloadFile https://raw.githubusercontent.com/datalad/datalad-installer/master/src/datalad_installer.py -FileName datalad_installer.py
 
 
 install:
@@ -145,14 +144,20 @@ install:
   # use of python/pip executables below
   - sh: "[ \"x$PY\" != x ] && . ${HOME}/venv${PY}/bin/activate || virtualenv -p 3 ${HOME}/dlvenv && . ${HOME}/dlvenv/bin/activate; ln -s \"$VIRTUAL_ENV\" \"${HOME}/VENV\""
   - cmd: "set PATH=C:\\Python%PY%;C:\\Python%PY%\\Scripts;%PATH%"
+  # deploy the datalad installer, override version via DATALAD_INSTALLER_VERSION
+  - cmd:
+      IF DEFINED DATALAD_INSTALLER_VERSION (
+      python -m pip install "datalad-installer%DATALAD_INSTALLER_VERSION%"
+      ) ELSE (
+      python -m pip install datalad-installer
+      )
+  - sh: python -m pip install datalad-installer${DATALAD_INSTALLER_VERSION:-}
   # Missing system software
   - sh: "[ -n \"$INSTALL_SYSPKGS\" ] && ( [ \"x${APPVEYOR_BUILD_WORKER_IMAGE}\" = \"xmacOS\" ] && brew install -q ${INSTALL_SYSPKGS} || sudo apt-get install --no-install-recommends -y ${INSTALL_SYSPKGS} ) || true"
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
-  - cmd: IF DEFINED INSTALL_GITANNEX python datalad_installer.py %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && python datalad_installer.py ${INSTALL_GITANNEX}"
-  # TODO remove when datalad-installer can handle this
-  - cmd: tools\ci\appveyor_install_git-annex.bat
+  - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
+  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
 
 
 #before_build:
@@ -160,8 +165,8 @@ install:
 
 
 build_script:
-  - pip install -r requirements-devel.txt
-  - pip install .
+  - python -m pip install -r requirements-devel.txt
+  - python -m pip install .
 
 
 #after_build:
@@ -169,6 +174,7 @@ build_script:
 
 
 before_test:
+  # simple call to see if datalad and git-annex are installed properly
   - datalad wtf
 
 

--- a/tools/ci/appveyor_install_git-annex.bat
+++ b/tools/ci/appveyor_install_git-annex.bat
@@ -1,5 +1,0 @@
-REM Install git-annex
-appveyor DownloadFile http://datasets.datalad.org/datalad/packages/windows/git-annex-installer_8.20201127+git11-g3be9dc6e1_x64.exe -FileName C:\DLTMP\git-annex-installer.exe
-REM 7z is preinstalled in all images
-REM Extract directly into system Git installation
-7z x -aoa -o"C:\\Program Files\Git" C:\DLTMP\git-annex-installer.exe


### PR DESCRIPTION
- get rid of custom git-annex installer script on windows, use the official implementation instead
- add support for requesting a specific installer version via ENV variable DATALAD_INSTALLER_VERSION, go with "latest" by default. Requesting an unavailable installer version will make the build error.
