### PR TITLE
Add missing/necessary files to sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,5 @@
-include versioneer.py
-include datalad_helloworld/_version.py
+include CONTRIBUTORS LICENSE versioneer.py
+graft _datalad_buildsupport
+graft docs
+prune docs/build
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools >= 30.3.0", "wheel"]
+requires = ["setuptools >= 43.0.0", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,10 @@ cmdclass = versioneer.get_cmdclass()
 cmdclass.update(build_manpage=BuildManPage)
 
 # Give setuptools a hint to complain if it's too old a version
-# 30.3.0 allows us to put most metadata in setup.cfg
+# 43.0.0 allows us to put most metadata in setup.cfg and causes pyproject.toml
+# to be automatically included in sdists
 # Should match pyproject.toml
-SETUP_REQUIRES = ['setuptools >= 30.3.0']
+SETUP_REQUIRES = ['setuptools >= 43.0.0']
 # This enables setuptools to install wheel on-the-fly
 SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
 


### PR DESCRIPTION
This PR adds the following files to sdists built from projects built from this template:

* `_datalad_buildsupport`; without this, building from an sdist is impossible
* `LICENSE`, so that it will be included in wheels built from sdists
* `CONTRIBUTORS` and `docs/`, which, in my opinion, should be included in sdists
* `pyproject.toml` (included by bumping the minimum setuptools version to 43.0.0)

Additionally, the `include datalad_helloworld/_version.py` line is removed from `MANIFEST.in` as it is unnecessary.