### PR TITLE
Remove `--universal` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ release-pypi:
 	# avoid upload of stale builds
 	test ! -e dist
 	$(PYTHON) setup.py sdist
-	python setup.py bdist_wheel --universal
+	python setup.py bdist_wheel
 	twine upload dist/*
 
 update-buildsupport:


### PR DESCRIPTION
The project metadata indicates that the template is for Python 3 only; thus, `--universal` should not be passed to `bdist_wheel`, as that option is only for projects that run on both Python 2 and Python 3.