### PR TITLE
Discontinue use of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,14 @@ classifiers =
 python_requires = >= 3.5
 install_requires =
     datalad >= 0.12.0
-test_requires =
-    nose
-    coverage
 packages = find:
 include_package_data = True
+
+[options.extras_require]
+# this matches the name used by -core and what is expected by some CI setups
+devel =
+    nose
+    coverage
 
 [options.packages.find]
 # do not ship the build helpers


### PR DESCRIPTION
To achieve compatibility with some of datalad's default CI setups.