### PR TITLE
Fix bdist_wheel command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ clean:
 release-pypi:
 	# avoid upload of stale builds
 	test ! -e dist
-	$(PYTHON) setup.py sdist
-	python setup.py bdist_wheel
+	$(PYTHON) setup.py sdist bdist_wheel
 	twine upload dist/*
 
 update-buildsupport:


### PR DESCRIPTION
The `bdist_wheel` command in the Makefile was not using the `PYTHON` setting.  This PR fixes that.  (Yes, "chaining" multiple `setup.py` commands as is done here is perfectly valid.)

Side note: The modern way to build a pyproject-using project is with [build](https://github.com/pypa/build) (Just by running `python3 -m build`), but I don't know whether (or how) you want to make that a dependency or not.