### PR TITLE
Stop using `setup_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,8 @@ from _datalad_buildsupport.setup import (
 cmdclass = versioneer.get_cmdclass()
 cmdclass.update(build_manpage=BuildManPage)
 
-# Give setuptools a hint to complain if it's too old a version
-# 43.0.0 allows us to put most metadata in setup.cfg and causes pyproject.toml
-# to be automatically included in sdists
-# Should match pyproject.toml
-SETUP_REQUIRES = ['setuptools >= 43.0.0']
-# This enables setuptools to install wheel on-the-fly
-SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
-
 if __name__ == '__main__':
     setup(name='datalad_helloworld',
           version=versioneer.get_version(),
           cmdclass=cmdclass,
-          setup_requires=SETUP_REQUIRES,
     )


### PR DESCRIPTION
As of the release of [setuptools v58.3.0](https://setuptools.pypa.io/en/latest/history.html#v58-3-0), the `setup_requires` argument to `setup()` is now officially deprecated.  It can and should be replaced by `build-system.requires` in `pyproject.toml`, which the code already does.