### PR TITLE
Replace _metalad with _helloworld for easier grepping

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -87,9 +87,9 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/datalad_metalad.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/datalad_helloworld.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/datalad_metalad.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/datalad_helloworld.qhc"
 
 applehelp:
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
@@ -104,8 +104,8 @@ devhelp:
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/datalad_metalad"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/datalad_metalad"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/datalad_helloworld"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/datalad_helloworld"
 	@echo "# devhelp"
 
 epub:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# datalad_metalad documentation build configuration file, created by
+# datalad_helloworld documentation build configuration file, created by
 # sphinx-quickstart on Tue Oct 13 08:41:19 2015.
 #
 # This file is execfile()d with the current directory set to its


### PR DESCRIPTION
Accidentally came upon mentions of `datalad_metalad` in the docs configuration file and renamed them for consistency and easier replacement based on `git grep datalad_helloworld`. This is a minor change.

Of course do not hesitate to throw this PR away if these were intentional.