### PR TITLE
Replace os.system with subprocess.run in doc-build

### DIFF
--- a/_datalad_buildsupport/setup.py
+++ b/_datalad_buildsupport/setup.py
@@ -156,40 +156,6 @@ class BuildManPage(Command):
                     f.write(formatted)
 
 
-class BuildRSTExamplesFromScripts(Command):
-    description = 'Generate RST variants of example shell scripts.'
-
-    user_options = [
-        ('expath=', None, 'path to look for example scripts'),
-        ('rstpath=', None, 'output path for RST files'),
-    ]
-
-    def initialize_options(self):
-        self.expath = opj('docs', 'examples')
-        self.rstpath = opj('docs', 'source', 'generated', 'examples')
-
-    def finalize_options(self):
-        if self.expath is None:
-            raise DistutilsOptionError('\'expath\' option is required')
-        if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
-        self.announce('Converting example scripts')
-
-    def run(self):
-        opath = self.rstpath
-        if not os.path.exists(opath):
-            os.makedirs(opath)
-
-        from glob import glob
-        for example in glob(opj(self.expath, '*.sh')):
-            exname = os.path.basename(example)[:-3]
-            with open(opj(opath, '{0}.rst'.format(exname)), 'w') as out:
-                fmt.cmdline_example_to_rst(
-                    open(example),
-                    out=out,
-                    ref='_example_{0}'.format(exname))
-
-
 class BuildConfigInfo(Command):
     description = 'Generate RST documentation for all config items.'
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@
 # serve to show the default.
 
 import sys
-import os
+import subprocess
 
 import datetime
 from os.path import (
@@ -35,19 +35,34 @@ import datalad_helloworld
 for setup_py_path in (opj(pardir, 'setup.py'),  # travis
                       opj(pardir, pardir, 'setup.py')):  # RTD
     if exists(setup_py_path):
-        sys.path.insert(0, os.path.abspath(dirname(setup_py_path)))
+        sys.path.insert(0, abspath(dirname(setup_py_path)))
+        # Build manpage
         try:
-            for cmd in 'manpage',: #'examples':
-                os.system(
-                    '{} build_{} --cmdsuite {} --manpath {} --rstpath {}'.format(
-                        setup_py_path,
-                        cmd,
-                        'datalad_helloworld:command_suite',
-                        abspath(opj(dirname(setup_py_path), 'build', 'man')),
-                        opj(dirname(__file__), 'generated', 'man')))
-        except:
+            subprocess.run(
+                args=[setup_py_path, 'build_manpage',
+                     '--cmdsuite', 'datalad_helloworld:command_suite',
+                     '--manpath', abspath(opj(
+                         dirname(setup_py_path), 'build', 'man')),
+                     '--rstpath', opj(dirname(__file__), 'generated', 'man'),
+                     ],
+                check=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
             # shut up and do your best
             pass
+        # Build examples (uncomment if needed)
+        # try:
+        #     subprocess.run(
+        #         args=[setup_py_path, 'build_examples',
+        #              '--expath', abspath(opj(
+        #                  dirname(__file__), pardir, 'examples')),
+        #              '--rstpath', opj(
+        #                  dirname(__file__), 'generated', 'examples'),
+        #              ],
+        #         check=True,
+        #     )
+        # except (FileNotFoundError, subprocess.CalledProcessError):
+        #     pass
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,19 +50,6 @@ for setup_py_path in (opj(pardir, 'setup.py'),  # travis
         except (FileNotFoundError, subprocess.CalledProcessError):
             # shut up and do your best
             pass
-        # Build examples (uncomment if needed)
-        # try:
-        #     subprocess.run(
-        #         args=[setup_py_path, 'build_examples',
-        #              '--expath', abspath(opj(
-        #                  dirname(__file__), pardir, 'examples')),
-        #              '--rstpath', opj(
-        #                  dirname(__file__), 'generated', 'examples'),
-        #              ],
-        #         check=True,
-        #     )
-        # except (FileNotFoundError, subprocess.CalledProcessError):
-        #     pass
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
This PR closes #33 and (hopefully) simplifies the doc-build code by removing the bits related to building examples. Removal was prompted by this comment by @mih: 
> It could very well be that the -neuroimaging extension is the last one to carry such examples. I think we have largely abandoned them as means of documentation after the handbook became available. Maybe a sufficient fix is to rip it out.

Additionally, this PR replaces `os.system` with newer `subprocess.run`.

I'm not sure if the style / formatting is optimal. Also, please do not hesitate if you think the removal was unnecessary.