### PR TITLE
RF: migrate to use pytest instead of nose, drop PY 3.6, require datalad >= 0.17.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -190,9 +190,8 @@ test_script:
   - cmd: md __testhome__
   - sh: mkdir __testhome__
   - cd __testhome__
-    # run test selecion (--traverse-namespace needed from Python 3.8 onwards)
-  - cmd: python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_helloworld %DTS%
-  - sh:  python -m nose --traverse-namespace -s -v -A "not (turtle)" --with-cov --cover-package datalad_helloworld ${DTS}
+  - cmd: python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_helloworld --pyargs %DTS%
+  - sh:  python -m pytest -s -v -m "not (turtle)" --doctest-modules --cov=datalad_helloworld --pyargs ${DTS}
 
 
 after_test:

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install dependencies
       run: |
         pip install -r requirements-devel.txt

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -52,4 +52,4 @@ jobs:
         echo "== mount >>"
         mount
         echo "<< mount =="
-        python -m nose -s -v --with-doctest --with-coverage --cover-package datalad_helloworld datalad_helloworld
+        python -m pytest -s -v --doctest-modules --cov=datalad_helloworld --pyargs datalad_helloworld

--- a/datalad_helloworld/__init__.py
+++ b/datalad_helloworld/__init__.py
@@ -26,9 +26,6 @@ command_suite = (
     ]
 )
 
-from datalad import setup_package
-from datalad import teardown_package
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/datalad_helloworld/conftest.py
+++ b/datalad_helloworld/conftest.py
@@ -1,0 +1,1 @@
+from datalad.conftest import setup_package

--- a/datalad_helloworld/tests/test_register.py
+++ b/datalad_helloworld/tests/test_register.py
@@ -1,4 +1,4 @@
-from datalad.tests.utils import assert_result_count
+from datalad.tests.utils_pytest import assert_result_count
 
 
 def test_register():

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,5 +1,6 @@
 # requirements for a development environment
-nose
+pytest
+pytest-cov
 coverage
 sphinx
 sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,8 +23,9 @@ include = datalad_helloworld*
 
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
+# Testing will require datalad >= 0.17 for migration to pytest.
 devel =
-    nose
+    pytest
     coverage
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.7
 install_requires =
-    datalad >= 0.12.0
+    datalad >= 0.17.0
 packages = find_namespace:
 include_package_data = True
 
@@ -23,7 +23,6 @@ include = datalad_helloworld*
 
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
-# Testing will require datalad >= 0.17 for migration to pytest.
 devel =
     pytest
     coverage


### PR DESCRIPTION
This is contingent on completion and release of migration over to pytest
in datalad core which is ongoing in

  https://github.com/datalad/datalad/pull/6273

which I think should happen in 0.17.  We should strive to make that PR
**not** break runtime (but can break testing) of extensions.

edit 1: converted to draft since we first need to migrate datalad core