### PR TITLE
Include "data packages" in projects

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include CONTRIBUTORS LICENSE versioneer.py
 graft _datalad_buildsupport
+graft datalad_helloworld
 graft docs
 prune docs/build
 global-exclude *.py[cod]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,19 +15,17 @@ classifiers =
 python_requires = >= 3.5
 install_requires =
     datalad >= 0.12.0
-packages = find:
+packages = find_namespace:
 include_package_data = True
+
+[options.packages.find]
+include = datalad_helloworld*
 
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
     nose
     coverage
-
-[options.packages.find]
-# do not ship the build helpers
-exclude=
-    _datalad_buildsupport
 
 [options.entry_points]
 # 'datalad.extensions' is THE entrypoint inspected by the datalad API builders


### PR DESCRIPTION
In the event that a templated project contains folders under `datalad_<name>/` that contain data files but no Python source code, this PR ensures that the folders will be included when the project is installed, following [the latest advice from setuptools](https://github.com/pypa/setuptools/issues/3340).