### PR TITLE
Skip appveyor builds on doc-only changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,6 +90,13 @@ matrix:
     - KNOWN2FAIL: 1
 
 
+# do not run the CI if only documentation changes were made
+# documentation builds are tested elsewhere and cheaper
+skip_commits:
+  files:
+    - docs/
+
+
 # it is OK to specify paths that may not exist for a particular test run
 cache:
   # pip cache


### PR DESCRIPTION
Done in -core and elsewhere.

Closes datalad/datalad-extension-template#37