### PR TITLE
BK: Add tox.ini with typing,lint (codespell); add workflows for codespell; update pyproject.toml

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem,versioneer.py
+# ignore-words-list = 
+# exclude-file = 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Linters
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up environment
+      uses: actions/checkout@v1
+      with:  # no need for the history
+        fetch-depth: 1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+    - name: Run linters
+      run: |
+        tox -e lint

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -1,0 +1,32 @@
+# This workflow is running types checks using `tox -e typing` you could do locally.
+# As type hinting is not yet fully and consistently done through out the project only
+# some (randomly) selected files (listed in tox.ini) will be checked.  Feel welcome
+# to add extra files to the list there. See https://github.com/datalad/datalad/issues/6884
+# for the overall goal/progress towards type hints coverage in DataLad.
+name: Type-check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  typing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+
+      - name: Run type checker
+        run: tox -e typing

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docs/build
 docs/source/generated
 build/
 dist/
+.idea/
+venvs/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ adjust as necessary. A good approach is to
   "Auto-release on PR merge" workflows by using the code in the
   `datalad/release-action` repository [as described in its
   README](https://github.com/datalad/release-action#command-labels).
+- (Optionally) adjust [`tox.ini`](./tox.ini) for `pytest` and `flake8` options
+  and `tox` environments to use.
 
 You can consider filling in the provided [.zenodo.json](.zenodo.json) file with
 contributor information and [meta data](https://developers.zenodo.org/#representation)

--- a/_datalad_buildsupport/formatters.py
+++ b/_datalad_buildsupport/formatters.py
@@ -75,7 +75,7 @@ class ManPageFormatter(argparse.HelpFormatter):
 
     def _mk_name(self, prog, desc):
         """
-        this method is in consitent with others ... it relies on
+        this method is in consistent with others ... it relies on
         distribution
         """
         desc = desc.splitlines()[0] if desc else 'it is in the name'

--- a/_datalad_buildsupport/formatters.py
+++ b/_datalad_buildsupport/formatters.py
@@ -75,7 +75,7 @@ class ManPageFormatter(argparse.HelpFormatter):
 
     def _mk_name(self, prog, desc):
         """
-        this method is in consistent with others ... it relies on
+        this method is inconsistent with others ... it relies on
         distribution
         """
         desc = desc.splitlines()[0] if desc else 'it is in the name'

--- a/datalad_helloworld/hello_cmd.py
+++ b/datalad_helloworld/hello_cmd.py
@@ -53,6 +53,7 @@ class HelloWorld(Interface):
     # signature must match parameter list above
     # additional generic arguments are added by decorators
     def __call__(language: str = 'en') -> Iterator[dict]:
+        msg: str | tuple[str, ...]
         if language == 'en':
             msg = 'Hello!'
         elif language == 'de':

--- a/datalad_helloworld/hello_cmd.py
+++ b/datalad_helloworld/hello_cmd.py
@@ -1,7 +1,10 @@
 """DataLad demo command"""
 
+from __future__ import annotations
+
 __docformat__ = 'restructuredtext'
 
+from collections.abc import Iterator
 from os.path import curdir
 from os.path import abspath
 
@@ -49,7 +52,7 @@ class HelloWorld(Interface):
     @eval_results
     # signature must match parameter list above
     # additional generic arguments are added by decorators
-    def __call__(language='en'):
+    def __call__(language: str = 'en') -> Iterator[dict]:
         if language == 'en':
             msg = 'Hello!'
         elif language == 'de':

--- a/datalad_helloworld/tests/test_register.py
+++ b/datalad_helloworld/tests/test_register.py
@@ -1,7 +1,7 @@
 from datalad.tests.utils_pytest import assert_result_count
 
 
-def test_register():
+def test_register() -> None:
     import datalad.api as da
     assert hasattr(da, 'hello_cmd')
     assert_result_count(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # wheel to get more lightweight (not EASY-INSTALL) entry-points
-requires = ["packaging", "setuptools>=40.8.0", "wheel"]
+requires = ["setuptools>=40.8.0", "wheel"]
 
 [tool.isort]
 force_grid_wrap = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
-requires = ["setuptools >= 43.0.0", "wheel"]
+# wheel to get more lightweight (not EASY-INSTALL) entry-points
+requires = ["packaging", "setuptools>=40.8.0", "wheel"]
+
+[tool.isort]
+force_grid_wrap = 2
+include_trailing_comma = true
+multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # wheel to get more lightweight (not EASY-INSTALL) entry-points
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools >= 43.0.0", "wheel"]
 
 [tool.isort]
 force_grid_wrap = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,10 @@ include = datalad_helloworld*
 [options.extras_require]
 # this matches the name used by -core and what is expected by some CI setups
 devel =
-    pytest
     coverage
+    mypy
+    pytest
+
 
 [options.entry_points]
 # 'datalad.extensions' is THE entrypoint inspected by the datalad API builders

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,13 @@ show_missing = True
 omit =
     # versioneer code
     datalad_helloworld/_version.py
+
+# We need to ignore all datalad imports since datalad
+# is not yet typed overall. Unfortunately documented in
+# https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
+# datalad-specific setting didn't work so we set for all imports.
+# TODO: remove whenever datalad is typed.
+# [mypy-datalad.*]
+[mypy]
+exclude = _version\.py$
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,3 +63,6 @@ omit =
 [mypy]
 exclude = _version\.py$
 ignore_missing_imports = True
+
+[mypy-datalad_helloworld._version]
+follow_imports = skip

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ skip_install = true
 deps =
     codespell~=2.0
 commands =
-    codespell -x .codespell-ignorelines -D- -I .codespell-ignorewords --skip "_version.py,*.pem" datalad_helloworld setup.py
+    codespell
 
 [testenv:flake8]
 commands = flake8 datalad_helloworld

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,75 @@
+[tox]
+envlist = py3,lint,typing
+#,flake8
+
+[testenv:py3]
+changedir = __testhome__
+commands = pytest -c ../tox.ini -v {posargs} --pyargs datalad_helloworld
+extras = devel
+passenv=HOME
+setenv=
+    DATALAD_LOG_LEVEL=DEBUG
+
+[testenv:lint]
+skip_install = true
+deps =
+    codespell~=2.0
+commands =
+    codespell -x .codespell-ignorelines -D- -I .codespell-ignorewords --skip "_version.py,*.pem" datalad_helloworld setup.py
+
+[testenv:flake8]
+commands = flake8 datalad_helloworld
+
+[testenv:typing]
+extras = devel
+commands =
+    mypy datalad_helloworld
+
+[testenv:venv]
+commands = {posargs}
+
+[pytest]
+filterwarnings =
+markers =
+    fail_slow
+    githubci_osx
+    githubci_win
+    integration
+    known_failure
+    known_failure_githubci_osx
+    known_failure_githubci_win
+    known_failure_osx
+    known_failure_windows
+    network
+    osx
+    probe_known_failure
+    serve_path_via_http
+    skip_if_adjusted_branch
+    skip_if_no_network
+    skip_if_on_windows
+    skip_if_root
+    skip_known_failure
+    skip_nomultiplex_ssh
+    skip_ssh
+    skip_wo_symlink_capability
+    slow
+    turtle
+    usecase
+    windows
+    with_config
+    with_fake_cookies_db
+    with_memory_keyring
+    with_sameas_remotes
+    with_testrepos
+    without_http_proxy
+
+[flake8]
+#show-source = True
+# E265 = comment blocks like @{ section, which it can't handle
+# E266 = too many leading '#' for block comment
+# E731 = do not assign a lambda expression, use a def
+# W293 = Blank line contains whitespace
+#ignore = E265,W293,E266,E731
+max-line-length = 120
+include = datalad_helloworld
+exclude = .tox,.venv,venv-debug,build,dist,doc,git/ext/

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,13 @@
+#
+# This file defines common developer helper commands, such as
+# - py3: perform unittest-ing using pytest
+# - lint: codespell the code to avoid typos
+# - flake8: conform code to PEP8 and beyond (not enabled by default)
+# - typing: ensure consistency in type annotations
+#
+# Moveover configuration for pytest and flake8 specified in this file
+# as well, so would be in effect even if used not through tox.
+#
 [tox]
 envlist = py3,lint,typing
 #,flake8


### PR DESCRIPTION
To make template better tested and IMHO we should start aiming for type annotation of code in (new) extensions, although datalad itself is not yet annotated.

@jwodder - is it feasible to aim for downstream libraries (like datalad extensions) to be type annotated although only small portion of datalad itself is type annotated ATM?
Could you help finishing up this PR (type annotations for that small `datalad_helloworld`)?

@mih I also quite like `pre-commit` with `black` now as used in `dandi-cli` and other projects. May be we could/should introduce that to extensions to encourage code/imports consistency etc?