### PR TITLE
Fix wrong license trove classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description_content_type = text/markdown; charset=UTF-8
 license = MIT
 classifiers =
     Programming Language :: Python
-    License :: OSI Approved :: BSD License
+    License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
 
 [options]


### PR DESCRIPTION
The current trove classifier specifies a BSD License, while all other locations say MIT. This PR changes it to MIT as well.