### PR TITLE
codespell: config, dedicated workflow  + 1 typo fix

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem
+# ignore-words-list = 
+# exclude-file = 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = .venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem
+skip = .venv,venvs,.git,build,*.egg-info,*.lock,.asv,.mypy_cache,.tox,fixtures,_version.py,*.pem,versioneer.py
 # ignore-words-list = 
 # exclude-file = 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ docs/build
 docs/source/generated
 build/
 dist/
+.idea/
+venvs/

--- a/_datalad_buildsupport/formatters.py
+++ b/_datalad_buildsupport/formatters.py
@@ -75,7 +75,7 @@ class ManPageFormatter(argparse.HelpFormatter):
 
     def _mk_name(self, prog, desc):
         """
-        this method is in consitent with others ... it relies on
+        this method is in consistent with others ... it relies on
         distribution
         """
         desc = desc.splitlines()[0] if desc else 'it is in the name'


### PR DESCRIPTION
Easier to digest (no typing checking) version of #45 to your review.  We already have added similar setup (no tox.ini) codespelling to many extensions, so it is really just a matter of consistency and not wasting more PRs per each new extension.