### PR TITLE
Update intersphinx_mapping format

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,7 +116,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
The "old" format of intersphinx_mapping is deprecated since Sphinx 6.2 and started causing warnings treated as errors in the doc build CI.

https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping

As a side note, the intersphinx extension "can generate links to the documentation of objects in external projects". The changed config option is just an example, even a comment in the file says so. Personally I don't think we need the capability to link to Python project docs by default, and intersphinx could be removed altogether. But since it was here already, and it probably doesn't hurt, it shall remain in an updated format as of this commit.