### PR TITLE
Move python and cli reference to separate doc pages

### DIFF
--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -1,0 +1,7 @@
+Command line reference
+======================
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/datalad-hello-cmd

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,21 +11,19 @@ API
 High-level API commands
 -----------------------
 
-.. currentmodule:: datalad.api
-.. autosummary::
-   :toctree: generated
+.. toctree::
+   :maxdepth: 2
 
-   hello_cmd
+   python_reference.rst
 
 
 Command line reference
 ----------------------
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   generated/man/datalad-hello-cmd
-
+   cli_reference.rst
 
 Indices and tables
 ==================

--- a/docs/source/python_reference.rst
+++ b/docs/source/python_reference.rst
@@ -1,0 +1,8 @@
+High-level API commands
+=======================
+
+.. currentmodule:: datalad.api
+.. autosummary::
+   :toctree: generated
+
+   hello_cmd


### PR DESCRIPTION
This helps tidy up the home page (only lists of commands, no table) and navigation bar (proper sections for High-level API commands and Command line reference). There are now 3 files instead of 1, but I think it's worth it. Closes #90 

Headings and structure (although not file names) follow [datalad-next]() docs.

Before: 
![Screenshot from 2023-10-09 16-52-06](https://github.com/datalad/datalad-extension-template/assets/11985212/481f2e32-9aab-4b39-8b06-84c0c8d7f24c)

After: 
![Screenshot from 2023-10-09 17-39-39](https://github.com/datalad/datalad-extension-template/assets/11985212/1692fd05-34bf-4498-b651-7631030b101f)

Changes not included here but worth considering to make things even leaner: remove sub-headings below API and keep just the list; rename "High-level api" to "Python api", keep the list only 1 level deep (instead of 2) -- however these are easy to tune after starting a new project.