### PR TITLE
Add `only_commits` to `.appveyor.yml`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -172,6 +172,15 @@ install:
   #- sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
 
 
+# only run the CI if there are code changes, tooling changes,
+# or changes in `.appveyor.yml`
+only_commits:
+  files:
+    - .appveyor.yml
+    - datalad_helloworld/
+    - tools/
+
+
 #before_build:
 #
 

--- a/changelog.d/pr-94.md
+++ b/changelog.d/pr-94.md
@@ -1,0 +1,4 @@
+### 🚀 Enhancements and New Features
+
+- Add an `only_comits.files` example to `.appveyor.yml`. This illustrates how to limit builds to code changes, tool changes, and changes in `.appveyor.yml` itself.
+  https://github.com/datalad/datalad-helloworld/pull/94 (by [@christian-monch](https://github.com/christian-monch))


### PR DESCRIPTION
This PR adds an `ony_commit` mapping to `.appveyor.yml` that illustrates how to límit CI builds to changes in code, tools
or `.appveyor.yml`.

The section has to be adapted if the directory names are changed. Otherwise some changes might not trigger to CI-builds.
