### PR TITLE
BF: use setuptools.errors.OptionError instead of now removed import of distutils.DistutilsOptionError; stop using python 3.8 in CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,7 @@
 #     will run until the file is removed (or 60 min have passed)
 #
 #   - in a terminal execute, for example, `C:\datalad_debug.bat 39` to set up the
-#     environment to debug in a Python 3.8 session (should generally match the
+#     environment to debug in a Python 3.9 session (should generally match the
 #     respective CI run configuration).
 
 
@@ -80,7 +80,7 @@ environment:
     - ID: MacP38core
       DTS: datalad_helloworld
       APPVEYOR_BUILD_WORKER_IMAGE: macos-monterey
-      PY: 3.8
+      PY: 3.9
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
       CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -13,10 +13,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: 3.9
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         pip install -r requirements-devel.txt
         pip install .
     - name: Build docs

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -28,10 +28,10 @@ jobs:
         git config --global user.email "test@github.land"
         git config --global user.name "GitHub Almighty"
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         pip install -r requirements-devel.txt

--- a/_datalad_buildsupport/setup.py
+++ b/_datalad_buildsupport/setup.py
@@ -13,8 +13,9 @@ from os.path import (
     dirname,
     join as opj,
 )
-from setuptools import Command, DistutilsOptionError
+from setuptools import Command
 from setuptools.config import read_configuration
+from setuptools.errors import OptionError
 
 import versioneer
 
@@ -51,11 +52,11 @@ class BuildManPage(Command):
 
     def finalize_options(self):
         if self.manpath is None:
-            raise DistutilsOptionError('\'manpath\' option is required')
+            raise OptionError('\'manpath\' option is required')
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         if self.parser is None:
-            raise DistutilsOptionError('\'parser\' option is required')
+            raise OptionError('\'parser\' option is required')
         mod_name, func_name = self.parser.split(':')
         fromlist = mod_name.split('.')
         try:
@@ -168,7 +169,7 @@ class BuildConfigInfo(Command):
 
     def finalize_options(self):
         if self.rstpath is None:
-            raise DistutilsOptionError('\'rstpath\' option is required')
+            raise OptionError('\'rstpath\' option is required')
         self.announce('Generating configuration documentation')
 
     def run(self):

--- a/changelog.d/pr-98.md
+++ b/changelog.d/pr-98.md
@@ -1,0 +1,5 @@
+### 🐛 Bug Fixes
+
+- BF: use setuptools.errors.OptionError instead of now removed import of distutils.DistutilsOptionError.
+  Stop using python 3.8 in CI (use 3.9).
+  [PR #98](https://github.com/datalad/datalad-extension-template/pull/98) (by [@yarikoptic](https://github.com/yarikoptic))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools >= 43.0.0", "wheel"]
+requires = ["setuptools >= 59.0.0", "wheel"]


### PR DESCRIPTION
setuptools.errors were introduced in 59.0.0 release.

See https://github.com/pypa/setuptools/issues/5000 for more rationale etc.