### PR TITLE
BF: replace url for codecov uploader for macos to versioned one with two archs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -83,7 +83,7 @@ environment:
       PY: 3.9
       INSTALL_GITANNEX: git-annex
       DATALAD_LOCATIONS_SOCKETS: /Users/appveyor/DLTMP/sockets
-      CODECOV_BINARY: https://uploader.codecov.io/latest/macos/codecov
+      CODECOV_BINARY: https://cli.codecov.io/v0.7.4/macos/codecov
 
 matrix:
   allow_failures:

--- a/changelog.d/pr-100.md
+++ b/changelog.d/pr-100.md
@@ -1,0 +1,3 @@
+### 🧪 Tests
+
+- BF: replace url for codecov uploader for macos to versioned one with two archs.  [PR #100](https://github.com/datalad/datalad-extension-template/pull/100) (by [@yarikoptic](https://github.com/yarikoptic))


### PR DESCRIPTION
Should prevent 'Bad CPU type in executable' for codecov upload. See e.g.
https://github.com/datalad/datalad/pull/7649
for more info etc
